### PR TITLE
Wider range of A0 values for in/off/out

### DIFF
--- a/include/NimbleTCode.h
+++ b/include/NimbleTCode.h
@@ -141,9 +141,12 @@ void NimbleTCode::handleAirChanges()
     if (!tcode->axisChanged("A0")) return;
     int val = tcode->axisRead("A0");
 
-    if (val < 5000) {
+    //    0-3333 = air out 
+    // 3334-6666 = valve off
+    // 6667-9999 = air in
+    if (val < 3334) {
         frame.air = -1;
-    } else if (val > 5000) {
+    } else if (val > 6666) {
         frame.air = 1;
     } else {
         frame.air = 0;


### PR DESCRIPTION
As a work around for MFP's percentages and potential rounding errors, the mapping for A0 values is changed to:
- `0-3333` = air out, 
- `3334-6666` = valve off
- `6667-9999` = air in.

In hopes of addressing #1 